### PR TITLE
Upgrade C/C++ standard

### DIFF
--- a/isixwaf/isix_cpudb.py
+++ b/isixwaf/isix_cpudb.py
@@ -107,8 +107,8 @@ def configure(cfg):
         else:
             raise WafError('Unable to use nano version of newlib with exceptions enabled')
     optflag = [ '-O%s' % cfg.options.optimize ]
-    cfg.env.CFLAGS += cflags + ['-std=gnu11', '-Werror=implicit-function-declaration' ] + optflag
-    cfg.env.CXXFLAGS += cflags + [ '-std=gnu++17' ] + optflag
+    cfg.env.CFLAGS += cflags + ['-std=gnu17', '-Werror=implicit-function-declaration' ] + optflag
+    cfg.env.CXXFLAGS += cflags + [ '-std=gnu++23', '-Wno-volatile' ] + optflag
     cfg.env.ASFLAGS += cflags + [ '-Wa,-mapcs-32' ] + optflag
     cfg.env.DEFINES += _get_flag(cfg.options.cpu,'defs')
     cfg.env.LDFLAGS += [ '-nostdlib', '-nostartfiles' ] + cflags + optflag

--- a/libisixdrvstm32/include/spi_device.hpp
+++ b/libisixdrvstm32/include/spi_device.hpp
@@ -36,28 +36,20 @@ public:
 		CS0, CS1, CS2, CS3,
 		CS_, //! Don't apply chip select
 	};
-	enum data_with
+	enum spi_mode
 	{
 		data_8b  = 0x00,//!< data_8b
-		data_16b = 0x01 //!< data_16b
-	};
-	enum polar
-	{
+		data_16b = 0x01, //!< data_16b
+
 		polar_cpol_low = 0x00,
-		polar_cpol_hi  = 0x02
-	};
-	enum phase
-	{
+		polar_cpol_hi  = 0x02,
+
 		phase_1edge = 0x00,
-		phase_2edge = 0x04
-	};
-	enum byte_order
-	{
+		phase_2edge = 0x04,
+
 		msb_first = 0x00,
-		lsb_first = 0x08
-	};
-	enum cs_conf
-	{
+		lsb_first = 0x08,
+
 		cs_software = 0x00,
 		cs_hardware = 0x10
 	};

--- a/libperiph/periph/include/periph/dma/channel.hpp
+++ b/libperiph/periph/include/periph/dma/channel.hpp
@@ -45,40 +45,29 @@ namespace detail {
 		static constexpr auto transfer_prio = 0x3000U;
 	}
 }
-	enum src_increment_mode {
+	enum transfer_mode : flags_t {
 		mode_src_ninc = 0 << 0,
-		mode_src_inc =  1 << 0
-	};
-	enum dst_increment_mode {
+		mode_src_inc =  1 << 0,
+
 		mode_dst_ninc = 0 << 1,
-		mode_dst_inc =  1 << 1
-	};
-	enum src_transfer_size : flags_t {
+		mode_dst_inc =  1 << 1,
+
 		mode_src_size_byte = 0 << 3,
 		mode_src_size_halfword = 1 << 3,
 		mode_src_size_word = 2 << 3,
-	};
 
-
-	enum dest_transfer_size : flags_t {
 		mode_dst_size_byte = 0 << 6,
 		mode_dst_size_halfword = 1 << 6,
 		mode_dst_size_word = 2 << 6,
-	};
 
-	enum transfer_mode : flags_t {
 		mode_single = 0 << 9,
 		mode_circural = 1 << 9,
-	};
 
-	enum transfer_prio : flags_t {
 		priority_low = 0 << 12,
 		priority_med = 1 << 12,
 		priority_hi  = 2 << 12,
-		priority_vhi = 3 << 12
-	};
+		priority_vhi = 3 << 12,
 
-	enum start_mode : flags_t {
 		mode_start_now		   = 0 << 13,
 		mode_start_delayed	   = 1 << 13,
 	};


### PR DESCRIPTION
Upgrade to latest standard supported by ARM GCC 12.3.1; C to gnu17, C++ to gnu23.

Clear warnings that came up as a result.