### PR TITLE
Fix qemu: fatal: Lockup HardFault

### DIFF
--- a/libfoundation/src/sys/tiny_alloc.c
+++ b/libfoundation/src/sys/tiny_alloc.c
@@ -50,17 +50,15 @@ static void tiny_alloc_init(void)
 {
   struct header *hp;
 
-  extern void *const _heap_start, *const _heap_end;
-
   mem_lock_init();
 
-  hp = _heap_start;
-  hp->h_size = _heap_end - _heap_start - sizeof(struct header);
+  extern unsigned char __heap_start[], __heap_end[];
+  hp = (void *)__heap_start;
+  hp->h_size = __heap_end - __heap_start - sizeof(struct header);
 
   hp->h.h_next = NULL;
   heap.free.h.h_next = hp;
   heap.free.h_size = 0;
-
 }
 #endif
 

--- a/libisix/kernel/mm/malloc/seqfit.c
+++ b/libisix/kernel/mm/malloc/seqfit.c
@@ -49,12 +49,12 @@ void seqfit_alloc_init(void)
 {
   struct header *hp;
 
-  extern void *const _heap_start, *const _heap_end;
-  if( (uintptr_t)_heap_start % ISIX_BYTE_ALIGNMENT_SIZE ) {
+  extern unsigned char __heap_start[], __heap_end[];
+  if( (uintptr_t)__heap_start % ISIX_BYTE_ALIGNMENT_SIZE ) {
 	  abort();
   }
-  hp = _heap_start;
-  hp->h_size = _heap_end - _heap_start - sizeof(struct header);
+  hp = (void *)__heap_start;
+  hp->h_size = __heap_end - __heap_start - sizeof(struct header);
 
   hp->h.h_next = NULL;
   heap.free.h.h_next = hp;

--- a/libisix/kernel/mm/malloc/tlsf_isix.c
+++ b/libisix/kernel/mm/malloc/tlsf_isix.c
@@ -30,10 +30,10 @@
 //! Initialize global heap
 void _isixp_alloc_init(void)
 {
-	extern void *const _heap_start, *const _heap_end;
+	extern unsigned char __heap_start[], __heap_end[];
 	size_t ret = init_memory_pool(
-			_heap_end - _heap_start,
-			_heap_start
+		__heap_end - __heap_start,
+		__heap_start
 	);
 	if( ret == (size_t)-1 ) {
 		isix_bug("Unable to create TSLF memory pool");

--- a/libperiph/periph/src/boot/crt/crt0.c
+++ b/libperiph/periph/src/boot/crt/crt0.c
@@ -1,6 +1,3 @@
-
-
-
 extern unsigned long _etext;
 extern unsigned long _sidata;
 extern unsigned long _sdata;
@@ -18,6 +15,7 @@ void _fini(void) {}
 static void empty_func(void) {}
 void _external_startup(void) __attribute__ ((weak, alias("empty_func")));
 void _external_exit(void) __attribute__ ((weak, alias("empty_func")));
+
 
 
 /*only the address of this symbol is taken by gcc*/
@@ -85,9 +83,8 @@ static void early_cpu_setup(void)
 __attribute__((noreturn))
 void _mcu_reset_handler_(void)
 {
-    extern unsigned long *const _heap_start, *const _heap_end;
-    unsigned long *pul_src, *pul_dest;
-    early_cpu_setup();
+	unsigned long *pul_src, *pul_dest;
+	early_cpu_setup();
     ///
     // Copy the data segment initializers from flash to SRAM.
     //
@@ -105,7 +102,8 @@ void _mcu_reset_handler_(void)
         *(pul_dest++) = 0;
     }
 	// Clear the heap
-	for(pul_dest = _heap_start; pul_dest < _heap_end; )
+	extern unsigned long __heap_start[], __heap_end[];
+	for(pul_dest = __heap_start; pul_dest < __heap_end; )
 	{
 		*(pul_dest++) = 0;
 	}

--- a/libperiph/scripts/arm/cortexm/flash.ld
+++ b/libperiph/scripts/arm/cortexm/flash.ld
@@ -124,9 +124,9 @@ SECTIONS
     .heap (NOLOAD):
     {
         . = ALIGN(8);
-        _heap_start = .;
+        PROVIDE(__heap_start = .);
         . = ORIGIN(RAM) + LENGTH(RAM);
-        _heap_end = .;
+        PROVIDE(__heap_end = .);
     } > RAM
    
 	/* <WAFINSERT> Additional extra sections **/

--- a/libperiph/wscript
+++ b/libperiph/wscript
@@ -30,7 +30,6 @@ def configure(conf):
 #Build script
 def build(bld):
     src = bld.path.ant_glob( 'periph/src/**/*.c' )
-    print(src)
     src += bld.path.ant_glob( 'periph/src/**/*.cpp' )
     vendor_path = os.path.join( 'vendor',bld.isix_get_arch(),bld.isix_get_subarch(),
             bld.isix_get_cpu_vendor(), bld.isix_get_cpu_family() )

--- a/libstm32/scripts/stm32_flash.ld
+++ b/libstm32/scripts/stm32_flash.ld
@@ -124,11 +124,11 @@ SECTIONS
     .heap (NOLOAD):
     {
         . = ALIGN(8);
-        _heap_start = .;
+        PROVIDE(__heap_start = .);
         . = ORIGIN(RAM) + LENGTH(RAM);
-        _heap_end = .;
+        PROVIDE(__heap_end = .);
     } > RAM
-   
+
 	/* <WAFINSERT> Additional extra sections **/
     
     /* after that it's only debugging information. */

--- a/libstm32/src/crt0.c
+++ b/libstm32/src/crt0.c
@@ -1,6 +1,3 @@
-
-
-
 extern unsigned long _etext;
 extern unsigned long _sidata;
 extern unsigned long _sdata;
@@ -86,9 +83,8 @@ static void early_cpu_setup(void)
 __attribute__((noreturn))
 void _mcu_reset_handler_(void)
 {
-        extern unsigned long *const _heap_start, *const _heap_end;
-        unsigned long *pul_src, *pul_dest;
-        early_cpu_setup();
+	unsigned long *pul_src, *pul_dest;
+	early_cpu_setup();
     ///
     // Copy the data segment initializers from flash to SRAM.
     //
@@ -106,7 +102,8 @@ void _mcu_reset_handler_(void)
         *(pul_dest++) = 0;
     }
 	// Clear the heap
-	for(pul_dest = _heap_start; pul_dest < _heap_end; )
+	extern unsigned long __heap_start[], __heap_end[];
+	for(pul_dest = __heap_start; pul_dest < __heap_end; )
 	{
 		*(pul_dest++) = 0;
 	}


### PR DESCRIPTION
* Bring back PROVIDE in LD scripts as it was the right approach to get heap bounds
* Declare heap bounds as arrays rather than chars because:
	- one doesn't have to use & to take address
	- unknown length makes it immune to GCC -Wstringop-overflow false positives